### PR TITLE
Added autorenewal.sh for cert signing

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,11 +79,12 @@ iTAK has two ways to utilize certificate enrollment - adding the server manually
 
 ## REPOSITORY NOTES
 
-Automatic certificate renewal has not been fully implemented.
-For now, you will need to renew and convert the public SSL cert prior to its expiration. This can be done via an embeded script in the repository.
-> Would like to modify and add this as a cronjob in the future setup by this install script
+**CHANGES MADE FOR AUTO RENEWAL AWAITING VALIDATION**
+~~Automatic certificate renewal has not been fully implemented.~~
+~~For now, you will need to renew and convert the public SSL cert prior to its expiration. This can be done via an embeded script in the repository.~~
+~~ > Would like to modify and add this as a cronjob in the future setup by this install script~~
 
-**Renewal Script POST install**
+~~ **Renewal Script POST install** ~~
 
     sudo bash /opt/tak/certs/certbot-jks.sh
     sudo systemctl restart takserver

--- a/README.md
+++ b/README.md
@@ -80,7 +80,11 @@ iTAK has two ways to utilize certificate enrollment - adding the server manually
 ## REPOSITORY NOTES
 
 **CHANGES MADE FOR AUTO RENEWAL AWAITING VALIDATION**
+
 ~~Automatic certificate renewal has not been fully implemented.~~
+
 ~~For now, you will need to renew and convert the public SSL cert prior to its expiration. This can be done via an embeded script in the repository.~~   
+
 **FIXED AND WAITING FOR FEEDBACK/VALIDATION**
+
 ~~Need to add script to increase memory usage and buffer on postgresql~~ 

--- a/README.md
+++ b/README.md
@@ -81,12 +81,6 @@ iTAK has two ways to utilize certificate enrollment - adding the server manually
 
 **CHANGES MADE FOR AUTO RENEWAL AWAITING VALIDATION**
 ~~Automatic certificate renewal has not been fully implemented.~~
-~~For now, you will need to renew and convert the public SSL cert prior to its expiration. This can be done via an embeded script in the repository.~~
-~~ > Would like to modify and add this as a cronjob in the future setup by this install script~~
-
-~~ **Renewal Script POST install** ~~
-
-    sudo bash /opt/tak/certs/certbot-jks.sh
-    sudo systemctl restart takserver
-    
-~~Need to add script to increase memory usage and buffer on postgresql~~ FIXED AND WAITING FOR FEEDBACK/VALIDATION
+~~For now, you will need to renew and convert the public SSL cert prior to its expiration. This can be done via an embeded script in the repository.~~   
+**FIXED AND WAITING FOR FEEDBACK/VALIDATION**
+~~Need to add script to increase memory usage and buffer on postgresql~~ 

--- a/scripts/certsigning/autorenewal-raw.sh
+++ b/scripts/certsigning/autorenewal-raw.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# Set the domain name
+domain=FQDN
+
+# Set the log file path
+log_file=/var/log/certbot_renewal.log
+
+# Check if the certificate has been renewed by certbot
+certbot_has_renewed=$(sudo certbot certificates | grep "$domain" | grep "Renew" | wc -l)
+
+if [ $certbot_has_renewed -gt 0 ]; then
+    # Renew the certificate
+    sudo rm /opt/tak/certs/files/letsencrypt/$domain.p12
+    sudo rm /opt/tak/certs/files/letsencrypt/$domain.jks
+
+    # Create certificates
+    sudo openssl pkcs12 -export -in /etc/letsencrypt/live/$domain/fullchain.pem -inkey /etc/letsencrypt/live/$domain/privkey.pem -name $domain -out /opt/tak/certs/files/letsencrypt/$domain.p12 -password pass:atakatak
+    sudo keytool -importkeystore -deststorepass atakatak -destkeystore /opt/tak/certs/files/letsencrypt/$domain.jks -srckeystore /opt/tak/certs/files/letsencrypt/$domain.p12 -srcstoretype PKCS12 -srcstorepass atakatak
+    yes | sudo keytool -import -alias bundle -trustcacerts -file /etc/letsencrypt/live/$domain/fullchain.pem -keystore /opt/tak/certs/files/letsencrypt/$domain.jks -storepass atakatak
+
+    # Modify Permissions to tak:tak
+    echo "Modifying Permissions of .p12 and .jks"
+    sudo chown tak:tak /opt/tak/certs/files/letsencrypt/$domain.p12
+    sudo chown tak:tak /opt/tak/certs/files/letsencrypt/$domain.jks
+
+    # Restart Tak Server
+    sudo systemctl restart takserver
+
+    # Log success message to file
+    echo "$(date '+%Y-%m-%d %H:%M:%S') - Successfully renewed certificate for $domain" >> $log_file
+else
+    # Log no action message to file
+    echo "$(date '+%Y-%m-%d %H:%M:%S') - Certificate for $domain not due for renewal" >> $log_file
+fi

--- a/scripts/certsigning/certbot-cloudflare.sh
+++ b/scripts/certsigning/certbot-cloudflare.sh
@@ -1,24 +1,3 @@
-clear
-sleep 3
-echo " "
-echo "CERTBOT-CLOUDFLARE API CHALLENGE"
-echo " "
-
-sudo mkdir temp
-sleep 1
-cloudflare_api_description1="To get your cloudflare API KEY, go to cloudflare.com. Then in your profile Click API tokens. Create Custom Token and name it appropriately."
-cloudflare_api_description2="Permissions: Zone:DNS:Edit"
-cloudflare_api_decriptions3="Zone Resources: Include:Specific zone:<insert root hostname here>"
-
-printf '%s\n' "$cloudflare_api_description1" | fold -s
-echo " "
-printf '%s\n' "$cloudflare_api_description2" | fold -s
-echo " "
-printf '%s\n' "$cloudflare_api_description3" | fold -s
-sleep 2
-
-echo -n "Please enter your cloudflare API token : "
-read -r API_TOKEN
 echo "$API_TOKEN" > temp/apitoken.txt
 echo " "
 sleep 1
@@ -27,6 +6,7 @@ sudo cp cloudflare-raw.ini temp/cloudflare.ini
 sudo cp getcert-cloudflare-raw.sh temp/getcert-cloudflare.sh
 sudo cp CoreConfig.xml-certsigning-raw.sh temp/CoreConfig.xml-certsigning.sh
 sudo cp certbot-jks-raw.sh temp/certbot-jks.sh
+sudo cp autorenwal-raw.sh temp/autorenewal.sh
 
 cd ..
 
@@ -42,6 +22,7 @@ sed -i "s/VAR_ORGANIZATION/$(cat temp/var_organization.txt)/g" temp/CoreConfig.x
 sed -i "s/VAR_ORGUNIT/$(cat temp/var_orgunit.txt)/g" temp/CoreConfig.xml-certsigning.sh
 sed -i "s/DOMAIN/$(cat temp/domain.txt)/g" temp/getcert-cloudflare.sh
 sed -i "s/DOMAIN/$(cat temp/domain.txt)/g" temp/certbot-jks.sh
+sed -i "s/FQDN/$(cat temp/domain.txt)/g" temp/autorenewal.sh
 sleep 2
 
 mkdir -p ~/.secrets/certbot/
@@ -52,7 +33,7 @@ sudo chmod 600 ~/.secrets/certbot/cloudflare.ini
 echo "We will now attempt to get a certificate from certbot using the API key you entered above"
 echo " "
 sleep 1
-echo "This will take approximg 90 seconds to complete"
+echo "This will take approximately 90 seconds to complete"
 echo " "
 sleep 1
 echo "Press enter when you are ready to continue..."
@@ -68,8 +49,16 @@ sleep 1
 sudo bash temp/certbot-jks.sh 
 sleep 1
 sudo cp temp/certbot-jks.sh /opt/tak/certs
+sudo cp temp/autorenwal.sh /opt/tak/certs
+sudo chmod +x /opt/tak/certs/autorenewal.sh
 sleep 1
-(sudo crontab -l; echo "0 03 15 * * /opt/tak/certs/certbot-jks.sh")|awk '!x[$0]++'|crontab - 
+echo " "
+echo "Creating cronjob for Autorenewal of Certs"
+echo " "
+sleep 1
+sudo bash crontab.sh
+sleep 1
+echo " "
 echo " "
 echo "Now modifying the CoreConfig.xml"
 echo " "

--- a/scripts/certsigning/crontab.sh
+++ b/scripts/certsigning/crontab.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# Define the command to be scheduled in cron
+CRON_COMMAND="0 0 * * * /opt/tak/certs/autorenewal.sh"
+
+# Write the command to a temporary file
+echo "${CRON_COMMAND}" > /tmp/cronjob
+
+# Add the command to the user's crontab
+crontab /tmp/cronjob
+
+# Remove the temporary file
+rm /tmp/cronjob


### PR DESCRIPTION
First attempt at auto-renewal with certbot for the takserver.

The script is based on 'certbot-jks.sh' which converts the letsencrypt format into a jks file that is used by tak. This script will check the expiration date and then renew the certificate if it's been renewed automatically by certbot. The cronjob for this is set up in another install script in this repo that's been modified (checks at midnight every day). 

Take note this does automatically restart the takserver if certbot has renewed the cert.